### PR TITLE
update/disconnect nitrado credentials command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dayzr-bot",
-  "version": "13.3.1",
+  "version": "13.3.2",
   "description": "A General Purpose Discord Bot for DayZ Nitrado Servers.",
   "main": "index.js",
   "nodemonConfig": {


### PR DESCRIPTION
Adds a command allowing users to delete their Nitrado credentials from the bot database. Essentially disconnecting their DayZ server from their Discord guild.
* `/server disconnect`

From issue https://github.com/SowinskiBraeden/dayz-reforger/issues/26